### PR TITLE
swap order of sender and args

### DIFF
--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -10,20 +10,15 @@
 /**
  * A type alias for a slot function.
  *
- * @param args - The args object emitted with the signal.
- *
  * @param sender - The object emitting the signal.
+ *
+ * @param args - The args object emitted with the signal.
  *
  * #### Notes
  * A slot is invoked when a signal to which it is connected is emitted.
- *
- * The order of slot arguments is reversed from the type declaration.
- * Since the `args` is typically the most important parameter for the
- * slot, the reversal allows the slot to declare a `sender` only when
- * it is actually required.
  */
 export
-type Slot<T, U> = (args: U, sender: T) => void;
+type Slot<T, U> = (sender: T, args: U) => void;
 
 
 /**
@@ -69,7 +64,7 @@ type Slot<T, U> = (args: U, sender: T) => void;
  *   export const valueChanged = new Signal<SomeClass, number>();
  * }
  *
- * function logger(value: number, sender: SomeClass): void {
+ * function logger(sender: SomeClass, value: number): void {
  *   console.log(sender.name, value);
  * }
  *
@@ -469,7 +464,7 @@ function emit(sender: any, signal: Signal<any, any>, args: any): void {
  */
 function invokeSlot(conn: IConnection, args: any): void {
   try {
-    conn.slot.call(conn.thisArg, args, conn.sender);
+    conn.slot.call(conn.thisArg, conn.sender, args);
   } catch (err) {
     console.error(err);
   }

--- a/test/src/properties.spec.ts
+++ b/test/src/properties.spec.ts
@@ -330,7 +330,7 @@ describe('properties', () => {
         let oldvals: number[] = [];
         let newvals: number[] = [];
         let notify = new Signal<Model, IChangedArgs<number>>();
-        let changed = (args: IChangedArgs<number>, sender: Model) => {
+        let changed = (sender: Model, args: IChangedArgs<number>) => {
           models.push(sender);
           names.push(args.name);
           oldvals.push(args.oldValue);

--- a/test/src/signaling.spec.ts
+++ b/test/src/signaling.spec.ts
@@ -14,11 +14,17 @@ import {
 
 class TestObject {
 
-  static one = new Signal<TestObject, void>();
+  private _testObjectStructuralProperty: any;
+}
 
-  static two = new Signal<TestObject, number>();
 
-  static three = new Signal<TestObject, string[]>();
+namespace TestObject {
+
+  export const one = new Signal<TestObject, void>();
+
+  export const two = new Signal<TestObject, number>();
+
+  export const three = new Signal<TestObject, string[]>();
 }
 
 
@@ -46,12 +52,12 @@ class TestHandler {
     this.oneCount++;
   }
 
-  onTwo(args: number, sender: TestObject): void {
+  onTwo(sender: TestObject, args: number): void {
     this.twoSender = sender;
     this.twoValue = args;
   }
 
-  onThree(args: string[], sender: TestObject): void {
+  onThree(sender: TestObject, args: string[]): void {
     args.push(this.name);
   }
 


### PR DESCRIPTION
Sender really should come first. For signals such as `Signal<Foo, void>` it doesn't make sense to pass the args first.